### PR TITLE
Fix parsing of age field of message

### DIFF
--- a/G7SensorKit/Messages/G7GlucoseMessage.swift
+++ b/G7SensorKit/Messages/G7GlucoseMessage.swift
@@ -20,7 +20,7 @@ public struct G7GlucoseMessage: SensorMessage, Equatable {
     public let sequence: UInt16
     public let trend: Double?
     public let data: Data
-    public let age: UInt8 // Amount of time elapsed (seconds) from sensor reading to BLE comms
+    public let age: UInt16 // Amount of time elapsed (seconds) from sensor reading to BLE comms
 
     public var hasReliableGlucose: Bool {
         return algorithmState.hasReliableGlucose
@@ -68,12 +68,12 @@ public struct G7GlucoseMessage: SensorMessage, Equatable {
     }
 
     init?(data: Data) {
-        //    0  1  2 3 4 5  6 7  8  9 10 11 1213 14 15 1617 18
-        //         TTTTTTTT SQSQ       AG    BGBG SS TR PRPR C
-        // 0x4e 00 d5070000 0900 00 01 05 00 6100 06 01 ffff 0e
+        //    0  1  2 3 4 5  6 7  8  9 1011 1213 14 15 1617 18
+        //         TTTTTTTT SQSQ       AGAG BGBG SS TR PRPR C
+        // 0x4e 00 d5070000 0900 00 01 0500 6100 06 01 ffff 0e
         // TTTTTTTT = timestamp
         //     SQSQ = sequence
-        //       AG = age
+        //     AGAG = age
         //     BGBG = glucose
         //       SS = algorithm state
         //       TR = trend
@@ -92,7 +92,7 @@ public struct G7GlucoseMessage: SensorMessage, Equatable {
 
         sequence = data[6..<8].to(UInt16.self)
 
-        age = data[10]
+        age = data[10..<12].to(UInt16.self)
 
         let glucoseData = data[12..<14].to(UInt16.self)
         if glucoseData != 0xffff {

--- a/G7SensorKitTests/G7GlucoseMessageTests.swift
+++ b/G7SensorKitTests/G7GlucoseMessageTests.swift
@@ -127,6 +127,12 @@ final class G7GlucoseMessageTests: XCTestCase {
         XCTAssertEqual(907385, message.glucoseTimestamp)
     }
 
+    func testBackfill() {
+        let data = Data(hexadecimalString: "cf5802008f00060f10")!
+        let message = G7BackfillMessage(data: data)!
+        XCTAssertEqual(153807, message.timestamp)
+    }
+
 }
 
 

--- a/G7SensorKitTests/G7GlucoseMessageTests.swift
+++ b/G7SensorKitTests/G7GlucoseMessageTests.swift
@@ -76,13 +76,13 @@ final class G7GlucoseMessageTests: XCTestCase {
         XCTAssertEqual(1400, messages[5].glucoseTimestamp)
         XCTAssertEqual(1700, messages[6].glucoseTimestamp)
         XCTAssertEqual(2000, messages[7].glucoseTimestamp)
-        XCTAssertEqual(934777, messages[8].glucoseTimestamp)
+        XCTAssertEqual(907385, messages[8].glucoseTimestamp)
     }
 
     func testG7MessageDataDetails() {
         //  0  1  2 3 4 5  6 7  8  9 10 11 1213 14 15 16 17 18
-        //       TTTTTTTT SQSQ       AG    BGBG SS          C
-        // 4e 00 a89c0000 8800 00 01 04 00 8d00 06 03 8a 00 0f
+        //       TTTTTTTT SQSQ       AGAG BGBG SS          C
+        // 4e 00 a89c0000 8800 00 01 0400 8d00 06 03 8a 00 0f
 
         //2022-09-12 09:18:06.821253 readEGV(txTime=40104,seq=136,session=1,age=4,value=141,pred=138,algo=6,subAlgo=15,rate=3)
         let data = Data(hexadecimalString: "4e00a89c00008800000104008d0006038a000f")!
@@ -110,51 +110,68 @@ final class G7GlucoseMessageTests: XCTestCase {
         let message = G7GlucoseMessage(data: data)!
         XCTAssertNil(message.trend)
     }
+
+    func testTwoByteAge() {
+        let data = Data(hexadecimalString: "4e00f9590200030200012a018f000610d9000f")!
+        let message = G7GlucoseMessage(data: data)!
+        XCTAssertEqual(298, message.age)
+        XCTAssertEqual(154105, message.messageTimestamp)
+        XCTAssertEqual(153807, message.glucoseTimestamp)
+    }
+
+    func testTwoByteAgeOnExpiredSensor() {
+        let data = Data(hexadecimalString: "4e004d440e00d40b0001d46b650018036a000e")!
+        let message = G7GlucoseMessage(data: data)!
+        XCTAssertEqual(27604, message.age) // 7 hours after expiration
+        XCTAssertEqual(934989, message.messageTimestamp)
+        XCTAssertEqual(907385, message.glucoseTimestamp)
+    }
+
 }
 
 
 
 // Activated 2022-09-24 17:39:31 +0000
 
-//                                0  1  2 3 4 5  6  7  8  9 10 11 1213 14 15 16 17 18
-//                                     TTTTTTTT                   BGBG SS          C
-// 2022-09-24 17:47:23           4e 00 ea010000 04 00 00 01 05 00 6c00 02 7e ff ff 02
-// 2022-09-24 17:52:27           4e 00 1a030000 05 00 00 01 09 00 5300 02 7e ff ff 02
-// 2022-09-24 17:57:25           4e 00 44040000 06 00 00 01 07 00 4500 02 e7 ff ff 02
-// 2022-09-24 18:02:27           4e 00 73050000 07 00 00 01 0a 00 3a00 02 f4 ff ff 02
-// 2022-09-24 18:07:21           4e 00 99060000 08 00 00 01 04 00 4800 06 02 ff ff 0e
-// 2022-09-24 18:22:26           4e 00 220a0000 0b 00 00 01 09 00 4f00 06 fe ff ff 0e
+//                                0  1  2 3 4 5  6  7  8  9 1011 1213 14 15 16 17 18
+//                                     TTTTTTTT             AGAG BGBG SS          C
+// 2022-09-24 17:47:23           4e 00 ea010000 04 00 00 01 0500 6c00 02 7e ff ff 02
+// 2022-09-24 17:52:27           4e 00 1a030000 05 00 00 01 0900 5300 02 7e ff ff 02
+// 2022-09-24 17:57:25           4e 00 44040000 06 00 00 01 0700 4500 02 e7 ff ff 02
+// 2022-09-24 18:02:27           4e 00 73050000 07 00 00 01 0a00 3a00 02 f4 ff ff 02
+// 2022-09-24 18:07:21           4e 00 99060000 08 00 00 01 0400 4800 06 02 ff ff 0e
+// 2022-09-24 18:22:26           4e 00 220a0000 0b 00 00 01 0900 4f00 06 fe ff ff 0e
 
-// 2022-09-24 18:27:22           4e 00 4a0b0000 0c 00 00 01 05 00 4900 06 f9 37 00 0f
+// 2022-09-24 18:27:22           4e 00 4a0b0000 0c 00 00 01 0500 4900 06 f9 37 00 0f
 // 2022-09-24 18:27:23  (txInfo: 7815(379013053518), SW13354, 73 mg⁠/⁠dL, Predictive: 55 mg⁠/⁠dL, Rate: -0.7 @ 2022-09-24T13:27:17-05:00, sessionInfo: Optional(Start: 2022-09-24T12:40:17-05:00, End: 2022-10-05T00:40:17-05:00)), isTimeCertain: true
 
-// 2022-09-24 22:32:24           4e 00 b7440000 3d 00 00 01 06 00 7f00 06 03 83 00 0f
+// 2022-09-24 22:32:24           4e 00 b7440000 3d 00 00 01 0600 7f00 06 03 83 00 0f
 //2022-09-24 17:32:27.248461 -0500    info    388    <Missing Description>    Dexcom G7    DisplayState: displayingGlucose(txInfo: 7815(379013053518), SW13354, 127 mg⁠/⁠dL, Predictive: 131 mg⁠/⁠dL, Rate: 0.3 @ 2022-09-24T17:32:18-05:00, sessionInfo: Optional(Start: 2022-09-24T12:40:18-05:00, End: 2022-10-05T00:40:18-05:00)), isTimeCertain: true
 
 
 
 
-//                                            0  1  2 3 4 5  6  7  8  9 10 11 1213 14 15 16 17 18
-//                                                 TTTTTTTT                   BGBG SS          C
-// 2022-10-04 23:27:39  106 timestamp:902888 4e 00 e8c60d00 c5 0b 00 01 03 00 6a00 06 01 6a 00 0f
-// 2022-10-04 23:32:40  101 timestamp:903189 4e 00 15c80d00 c6 0b 00 01 04 00 6500 06 fe 61 00 0f
-// 2022-10-04 23:37:39  98  timestamp:903488 4e 00 40c90d00 c7 0b 00 01 03 00 6200 06 fc 5e 00 0f
-// 2022-10-04 23:42:39  100 timestamp:903789 4e 00 6dca0d00 c8 0b 00 01 04 00 6400 06 ff 5e 00 0f
-// 2022-10-04 23:47:41  97  timestamp:904090 4e 00 9acb0d00 c9 0b 00 01 05 00 6100 06 fd 5c 00 0f
+//                                            0  1  2 3 4 5  6  7  8  9 1011 1213 14 15 16 17 18
+//                                                 TTTTTTTT             AGAG BGBG SS          C
+// 2022-10-04 23:27:39  106 timestamp:902888 4e 00 e8c60d00 c5 0b 00 01 0300 6a00 06 01 6a 00 0f
+// 2022-10-04 23:32:40  101 timestamp:903189 4e 00 15c80d00 c6 0b 00 01 0400 6500 06 fe 61 00 0f
+// 2022-10-04 23:37:39  98  timestamp:903488 4e 00 40c90d00 c7 0b 00 01 0300 6200 06 fc 5e 00 0f
+// 2022-10-04 23:42:39  100 timestamp:903789 4e 00 6dca0d00 c8 0b 00 01 0400 6400 06 ff 5e 00 0f
+// 2022-10-04 23:47:41  97  timestamp:904090 4e 00 9acb0d00 c9 0b 00 01 0500 6100 06 fd 5c 00 0f
 
-// 2022-10-04 23:52:41  97  timestamp:904390 4e 00 c6cc0d00 ca 0b 00 01 05 00 6100 06 fe 5b 00 0f
+// 2022-10-04 23:52:41  97  timestamp:904390 4e 00 c6cc0d00 ca 0b 00 01 0500 6100 06 fe 5b 00 0f
 
 // 2022-10-04 23:52:41.100991 -0500    info    289    <Missing Description>    Dexcom G7    calBounds(signature=65,lastBG=100,lastBGTime=901259,processing=completeHigh,permitted=true,lastDisplay=phone,lastProcessingTime=901565)
 // 2022-10-04 23:52:41.260740 -0500    info    289    <Missing Description>    Dexcom G7    DisplayState: displayingGlucose(txInfo: 7815(379013053518), SW13354, 97 mg⁠/⁠dL, Predictive: 91 mg⁠/⁠dL, Rate: -0.2 @ 2022-10-04T23:52:36-05:00, sessionInfo: Optional(Start: 2022-09-24T12:40:36-05:00, End: 2022-10-05T00:40:36-05:00)), isTimeCertain: true
 //
 
-// 2022-10-04 23:57:52  98  timestamp:904701 4e 00 fdcd0d00 cb 0b 00 01 10 00 6200 06 00 5c 00 0f
-// 2022-10-05 00:02:40  96  timestamp:904989 4e 00 1dcf0d00 cc 0b 00 01 04 00 6000 06 fe 5b 00 0f
-// 2022-10-05 00:07:39  95  timestamp:905288 4e 00 48d00d00 cd 0b 00 01 03 00 5f00 06 fe 5a 00 0f
-// 2022-10-05 08:17:43  101 timestamp:934692 4e 00 24430e00 d4 0b 00 01 ab 6a 6500 18 03 6a 00 0e
-// 2022-10-05 08:22:40  101 timestamp:934989 4e 00 4d440e00 d4 0b 00 01 d4 6b 6500 18 03 6a 00 0e
-// 2022-10-05 08:27:40  101 timestamp:935289 4e 00 79450e00 d4 0b 00 01 00 6d 6500 18 03 6a 00 0e
-// 2022-10-05 08:32:42  101 timestamp:935590 4e 00 a6460e00 d4 0b 00 01 2d 6e 6500 18 03 6a 00 0e
-// 2022-10-05 08:37:42  101 timestamp:935890 4e 00 d2470e00 d4 0b 00 01 59 6f 6500 18 03 6a 00 0e
-// 2022-10-05 08:42:39  101 timestamp:936188 4e 00 fc480e00 d4 0b 00 01 83 70 6500 18 03 6a 00 0e
-// 2022-10-05 08:47:39  101 timestamp:936488 4e 00 284a0e00 d4 0b 00 01 af 71 6500 18 03 6a 00 0e
+// 2022-10-04 23:57:52  98  timestamp:904701 4e 00 fdcd0d00 cb 0b 00 01 1000 6200 06 00 5c 00 0f
+// 2022-10-05 00:02:40  96  timestamp:904989 4e 00 1dcf0d00 cc 0b 00 01 0400 6000 06 fe 5b 00 0f
+// 2022-10-05 00:07:39  95  timestamp:905288 4e 00 48d00d00 cd 0b 00 01 0300 5f00 06 fe 5a 00 0f
+// 2022-10-05 08:17:43  101 timestamp:934692 4e 00 24430e00 d4 0b 00 01 ab6a 6500 18 03 6a 00 0e
+// 2022-10-05 08:22:40  101 timestamp:934989 4e 00 4d440e00 d4 0b 00 01 d46b 6500 18 03 6a 00 0e
+// 2022-10-05 08:27:40  101 timestamp:935289 4e 00 79450e00 d4 0b 00 01 006d 6500 18 03 6a 00 0e
+// 2022-10-05 08:32:42  101 timestamp:935590 4e 00 a6460e00 d4 0b 00 01 2d6e 6500 18 03 6a 00 0e
+// 2022-10-05 08:37:42  101 timestamp:935890 4e 00 d2470e00 d4 0b 00 01 596f 6500 18 03 6a 00 0e
+// 2022-10-05 08:42:39  101 timestamp:936188 4e 00 fc480e00 d4 0b 00 01 8370 6500 18 03 6a 00 0e
+// 2022-10-05 08:47:39  101 timestamp:936488 4e 00 284a0e00 d4 0b 00 01 af71 6500 18 03 6a 00 0e


### PR DESCRIPTION
The age field is not a single byte, but a little endian word. User reported seeing duplicate g7 values in [zulip](https://loop.zulipchat.com/#narrow/stream/144111-general/topic/duplicate.20g7.20glucose.20values.203.2E2.2E2/near/366078673).  The duplication happened because the current glucose message was parsed as having a different (wrong) timestamp almost 5 minutes different from the backfill timestamp.