### PR TITLE
Use appName instead of hard-coded Loop in strings

### DIFF
--- a/G7SensorKit.xcodeproj/project.pbxproj
+++ b/G7SensorKit.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		B60BB2E42BC649DA00D2BB39 /* Bundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = B60BB2E32BC649DA00D2BB39 /* Bundle.swift */; };
 		C109F14A291ECCE2008EA5B6 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C109F149291ECCE2008EA5B6 /* Assets.xcassets */; };
 		C109F14C291ED66F008EA5B6 /* G7GlucoseMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C109F14B291ED66F008EA5B6 /* G7GlucoseMessageTests.swift */; };
 		C139829829295D7D0047DB5F /* HKUnit.swift in Sources */ = {isa = PBXBuildFile; fileRef = C17F514A291EB6F000555EB5 /* HKUnit.swift */; };
@@ -106,6 +107,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		B60BB2E32BC649DA00D2BB39 /* Bundle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Bundle.swift; path = G7SensorKitUI/Extensions/Bundle.swift; sourceTree = SOURCE_ROOT; };
 		C1086B0E29C9169100D46E65 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
 		C1086B0F29C9169100D46E65 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
 		C109F149291ECCE2008EA5B6 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -318,6 +320,7 @@
 			children = (
 				C17F5103291EAC9D00555EB5 /* G7CGMManager+UI.swift */,
 				C17F5104291EAC9D00555EB5 /* G7UICoordinator.swift */,
+				B60BB2E32BC649DA00D2BB39 /* Bundle.swift */,
 			);
 			path = G7CGMManager;
 			sourceTree = "<group>";
@@ -636,6 +639,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C17F5108291EAC9D00555EB5 /* G7SettingsView.swift in Sources */,
+				B60BB2E42BC649DA00D2BB39 /* Bundle.swift in Sources */,
 				C17F5157291EBD9900555EB5 /* TimeInterval.swift in Sources */,
 				C19C9F4E29C91C4C00A6D3D0 /* LocalizedString.swift in Sources */,
 				C17F5156291EBD8600555EB5 /* Image.swift in Sources */,

--- a/G7SensorKit.xcodeproj/project.pbxproj
+++ b/G7SensorKit.xcodeproj/project.pbxproj
@@ -320,7 +320,6 @@
 			children = (
 				C17F5103291EAC9D00555EB5 /* G7CGMManager+UI.swift */,
 				C17F5104291EAC9D00555EB5 /* G7UICoordinator.swift */,
-				B60BB2E32BC649DA00D2BB39 /* Bundle.swift */,
 			);
 			path = G7CGMManager;
 			sourceTree = "<group>";
@@ -369,6 +368,7 @@
 		C17F5154291EBD7100555EB5 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				B60BB2E32BC649DA00D2BB39 /* Bundle.swift */,
 				C17F5155291EBD8600555EB5 /* Image.swift */,
 			);
 			path = Extensions;

--- a/G7SensorKitUI/Extensions/Bundle.swift
+++ b/G7SensorKitUI/Extensions/Bundle.swift
@@ -1,0 +1,15 @@
+//
+//  Bundle.swift
+//  LoopOnboardingKitUI
+//
+//  Created by Darin Krauss on 1/23/21.
+//  Copyright © 2021 LoopKit Authors. All rights reserved.
+//
+
+import Foundation
+
+extension Bundle {
+    var bundleDisplayName: String {
+        return object(forInfoDictionaryKey: "CFBundleDisplayName") as! String
+    }
+}

--- a/G7SensorKitUI/Extensions/Bundle.swift
+++ b/G7SensorKitUI/Extensions/Bundle.swift
@@ -1,6 +1,6 @@
 //
 //  Bundle.swift
-//  LoopOnboardingKitUI
+//  G7SensorKit
 //
 //  Created by Darin Krauss on 1/23/21.
 //  Copyright © 2021 LoopKit Authors. All rights reserved.

--- a/G7SensorKitUI/G7CGMManager/G7UICoordinator.swift
+++ b/G7SensorKitUI/G7CGMManager/G7UICoordinator.swift
@@ -54,6 +54,7 @@ class G7UICoordinator: UINavigationController, CGMManagerOnboarding, CompletionN
                     }
                 }
             )
+            .environment(\.appName, Bundle.main.bundleDisplayName)
             let hostingController = DismissibleHostingController(content: rootView, colorPalette: colorPalette)
             hostingController.navigationItem.largeTitleDisplayMode = .never
             hostingController.title = nil

--- a/G7SensorKitUI/Views/G7StartupView.swift
+++ b/G7SensorKitUI/Views/G7StartupView.swift
@@ -28,7 +28,7 @@ struct G7StartupView: View {
                     .frame(height: 120)
                     .padding(.horizontal)
             }.frame(maxWidth: .infinity)
-            Text(LocalizedString("\(self.appName) can read G7 CGM data, but you must still use the Dexcom G7 App for pairing, calibration, and other sensor management.", comment: "Descriptive text on G7StartupView"))
+            Text(String(format: LocalizedString("%1$@ can read G7 CGM data, but you must still use the Dexcom G7 App for pairing, calibration, and other sensor management.", comment: "Descriptive text on G7StartupView  (1: appName)"), self.appName))
                 .fixedSize(horizontal: false, vertical: true)
                 .foregroundColor(.secondary)
             Spacer()

--- a/G7SensorKitUI/Views/G7StartupView.swift
+++ b/G7SensorKitUI/Views/G7StartupView.swift
@@ -28,7 +28,7 @@ struct G7StartupView: View {
                     .frame(height: 120)
                     .padding(.horizontal)
             }.frame(maxWidth: .infinity)
-            Text(LocalizedString("\(self.appName) can read G7 CGM data, but you must still use the Dexcom G7 App for pairing, calibration, and other sensor management.", comment: "Instructions for G7"))
+            Text(LocalizedString("\(self.appName) can read G7 CGM data, but you must still use the Dexcom G7 App for pairing, calibration, and other sensor management.", comment: "Descriptive text on G7StartupView"))
                 .fixedSize(horizontal: false, vertical: true)
                 .foregroundColor(.secondary)
             Spacer()

--- a/G7SensorKitUI/Views/G7StartupView.swift
+++ b/G7SensorKitUI/Views/G7StartupView.swift
@@ -13,6 +13,8 @@ struct G7StartupView: View {
     var didContinue: (() -> Void)?
     var didCancel: (() -> Void)?
 
+    @Environment(\.appName) private var appName
+
     var body: some View {
         VStack(alignment: .center, spacing: 20) {
             Spacer()
@@ -26,7 +28,7 @@ struct G7StartupView: View {
                     .frame(height: 120)
                     .padding(.horizontal)
             }.frame(maxWidth: .infinity)
-            Text(LocalizedString("Loop can read G7 CGM data, but you must still use the Dexcom G7 App for pairing, calibration, and other sensor management.", comment: "Descriptive text on G7StartupView"))
+            Text(LocalizedString("\(self.appName) can read G7 CGM data, but you must still use the Dexcom G7 App for pairing, calibration, and other sensor management.", comment: "Instructions for G7"))
                 .fixedSize(horizontal: false, vertical: true)
                 .foregroundColor(.secondary)
             Spacer()


### PR DESCRIPTION
Replace the hard-coded "Loop" string with appName, which is tied to CFBundleDisplayName.