### PR TITLE
Add ONE+ to the display name for CGM selection

### DIFF
--- a/G7SensorPlugin/Info.plist
+++ b/G7SensorPlugin/Info.plist
@@ -23,7 +23,7 @@
 	<key>NSPrincipalClass</key>
 	<string>G7SensorPlugin</string>
 	<key>com.loopkit.Loop.CGMManagerDisplayName</key>
-	<string>Dexcom G7</string>
+	<string>Dexcom G7 / ONE+</string>
 	<key>com.loopkit.Loop.CGMManagerIdentifier</key>
 	<string>G7CGMManager</string>
 </dict>


### PR DESCRIPTION
This PR just changes the name of `Dexcom G7` to `Dexcom G7 / ONE+` when selecting a CGM to make it more clear to Dexcom ONE+ users which option they need to select.

Note: The 2nd screenshot also shows `Dexcom G6` changed to `Dexcom G6 / ONE`, which is handled by a separate [PR](https://github.com/LoopKit/CGMBLEKit/pull/194) to CGMBLEKit.

| current Loop-dev | with this PR |
| --- | --- |
| ![before](https://github.com/user-attachments/assets/7d7fd248-2b2a-49d4-a8f4-c492f0487fac) | ![after](https://github.com/user-attachments/assets/90749161-4aeb-4757-ba4f-15c49ba4f8af) |

Tested with the latest Loop-dev a68758871bd4ed8545fc011d04c23c72eb3f2ce8