### PR TITLE
Swedish translations

### DIFF
--- a/G7SensorKit/sv.lproj/Localizable.strings
+++ b/G7SensorKit/sv.lproj/Localizable.strings
@@ -1,12 +1,23 @@
+/* CGM display title */
+"Dexcom G7" = "Dexcom G7";
+
 /* Error description for unreliable state */
 "Glucose data is unavailable" = "Glukosvärden är inte tillgängliga";
 
+/* The description of sensor algorithm state when sensor is expired. */
+"Sensor expired" = "Sensorn har gått ut";
+
+/* The description of sensor algorithm state when sensor failed. */
+"Sensor failed" = "Sensorn har misslyckats";
+
 /* The description of sensor algorithm state when raw value is unknown. (1: missing data details) */
 "Sensor is in unknown state %1$d" = "Sensorns status är okänd %1$d";
+
+/* The description of sensor algorithm state when sensor is ok. */
+"Sensor is OK" = "Sensorn är OK";
 
 /* The description of sensor algorithm state when sensor is stopped. */
 "Sensor is stopped" = "Sensorn har stoppats";
 
 /* The description of sensor algorithm state when sensor is warming up. */
 "Sensor is warming up" = "Sensorn värmer upp";
-

--- a/G7SensorKitUI/Views/G7SettingsView.swift
+++ b/G7SensorKitUI/Views/G7SettingsView.swift
@@ -76,7 +76,7 @@ struct G7SettingsView: View {
                 }
             }
 
-            Section("Last Reading") {
+            Section(header: Text(LocalizedString("Last Reading", comment: "Section header for Last Reading"))) {
                 LabeledValueView(label: LocalizedString("Glucose", comment: "Field label"),
                                  value: viewModel.lastGlucoseString)
                 LabeledDateView(label: LocalizedString("Time", comment: "Field label"),
@@ -86,7 +86,7 @@ struct G7SettingsView: View {
                                  value: viewModel.lastGlucoseTrendString)
             }
 
-            Section("Bluetooth") {
+            Section(header: Text(LocalizedString("Bluetooth", comment: "Section header for Bluetooth"))) {
                 if let name = viewModel.sensorName {
                     HStack {
                         Text(LocalizedString("Name", comment: "title for g7 settings row showing BLE Name"))
@@ -118,7 +118,7 @@ struct G7SettingsView: View {
                 }
             }
 
-            Section("Configuration") {
+            Section(header: Text(LocalizedString("Configuration", comment: "Section header for Configuration"))) {
                 HStack {
                     Toggle(LocalizedString("Upload Readings", comment: "title for g7 config settings to upload readings"), isOn: $viewModel.uploadReadings)
                 }
@@ -134,7 +134,7 @@ struct G7SettingsView: View {
 
             Section () {
                 if !self.viewModel.scanning {
-                    Button("Scan for new sensor", action: {
+                    Button(LocalizedString("Scan for new sensor", comment: "Button title for scanning for a new sensor"), action: {
                         self.viewModel.scanForNewSensor()
                     })
                 }
@@ -212,7 +212,7 @@ struct G7SettingsView: View {
 
 
     private var doneButton: some View {
-        Button("Done", action: {
+        Button(NSLocalizedString("Done", comment: "Done button in settings view"), action: {
             self.didFinish()
         })
     }

--- a/G7SensorKitUI/sv.lproj/Localizable.strings
+++ b/G7SensorKitUI/sv.lproj/Localizable.strings
@@ -1,13 +1,19 @@
 /* No glucose value representation (3 dashes for mg/dL) */
 "– – –" = "– – –";
 
+/* Descriptive text on G7StartupView  (1: appName) */
+"%1$@ can read G7 CGM data, but you must still use the Dexcom G7 App for pairing, calibration, and other sensor management." = "%1$@ kan läsa G7 CGM-data, men du måste fortfarande använda Dexcom G7-appen för parkoppling, kalibrering och annan sensorhantering.";
+
 /* No comment provided by engineer. */
 "Are you sure you want to delete this CGM?" = "Är du säker på att du vill radera denna CGM?";
+
+/* Section header for Bluetooth */
+"Bluetooth" = "Bluetooth";
 
 /* Button text to cancel G7 setup */
 "Cancel" = "Avbryt";
 
-/* No comment provided by engineer. */
+/* Section header for Configuration */
 "Configuration" = "Konfiguration";
 
 /* title for g7 settings connection status when connected */
@@ -22,20 +28,81 @@
 /* Button label for removing CGM */
 "Delete CGM" = "Radera CGM";
 
-/* No comment provided by engineer. */
-"Done" = "Färdig";
+/* Navigation bar title for G7SettingsView
+   Title on WelcomeView */
+"Dexcom G7" = "Dexcom G7";
+
+/* Done button in settings view */
+"Done" = "Klar";
 
 /* Field label */
 "Glucose" = "Glukos";
 
+/* title for g7 settings row showing sensor grace period end time */
+"Grace Period End" = "Respitperiodens slut";
+
+/* G7 Progress bar label when sensor grace period progress showing */
+"Grace period remaining" = "Respitperiod kvar";
+
 /* String displayed instead of a glucose value above the CGM range */
 "HIGH" = "HÖGT";
+
+/* title for g7 settings row showing sensor last connect time */
+"Last Connect" = "Senast ansluten";
+
+/* Section header for Last Reading */
+"Last Reading" = "Senaste avläsningen";
 
 /* String displayed instead of a glucose value below the CGM range */
 "LOW" = "LÅGT";
 
 /* title for g7 settings row showing BLE Name */
 "Name" = "Namn";
+
+/* Opens the dexcom G7 app to allow users to manage active sensors */
+"Open Dexcom App" = "Öppna Dexcom-appen";
+
+/* Button title for scanning for a new sensor */
+"Scan for new sensor" = "Sök efter ny sensor";
+
+/* title for g7 settings connection status when scanning */
+"Scanning" = "Söker";
+
+/* G7 Status highlight text for searching for sensor */
+"Searching for\nSensor" = "Söker efter\nsensor";
+
+/* G7 Progress bar label when searching for sensor */
+"Searching for sensor" = "Söker efter sensor";
+
+/* G7 Status highlight text for sensor expired */
+"Sensor\nExpired" = "Sensor\nutgått";
+
+/* G7 Status highlight text for sensor failed */
+"Sensor\nFailed" = "Sensor\nmisslyckades";
+
+/* G7 Status highlight text for sensor error */
+"Sensor\nIssue" = "Sensor\nfel";
+
+/* G7 Status highlight text for sensor warmup */
+"Sensor\nWarmup" = "Sensor\nuppvärmning";
+
+/* title for g7 settings row showing sensor expiration time */
+"Sensor Expiration" = "Sensorns utgångsdatum";
+
+/* G7 Progress bar label when sensor expired */
+"Sensor expired" = "Sensor utgången";
+
+/* G7 Progress bar label when sensor lifetime progress showing */
+"Sensor expires" = "Sensorn går ut";
+
+/* G7 Progress bar label when sensor failed */
+"Sensor failed" = "Sensor misslyckades";
+
+/* title for g7 settings row showing sensor start time */
+"Sensor Start" = "Sensorstart";
+
+/* G7 Status highlight text for signal loss */
+"Signal\nLoss" = "Tappad\nsignal";
 
 /* Field label */
 "Time" = "Tid";
@@ -46,3 +113,5 @@
 /* title for g7 config settings to upload readings */
 "Upload Readings" = "Ladda upp avläsningar";
 
+/* G7 Progress bar label when sensor in warmup */
+"Warmup completes" = "Uppvärmning slutförs";


### PR DESCRIPTION
I noticed that there were a lot of missing Swedish translations in general for the Loop app. This PR addresses this in the G7SensorKit repository.

- Added missing Swedish translations in the respective `Localizable.strings` files.
- Added `LocalizedString` calls where needed, which will help with other translations as well.
- Removed outdated translations that are no longer needed.