### PR TITLE
G7 End of session detection bugfix

### DIFF
--- a/G7SensorKit/AlgorithmError.swift
+++ b/G7SensorKit/AlgorithmError.swift
@@ -37,12 +37,14 @@ extension AlgorithmState {
                 return LocalizedString("Sensor is OK", comment: "The description of sensor algorithm state when sensor is ok.")
             case .stopped:
                 return LocalizedString("Sensor is stopped", comment: "The description of sensor algorithm state when sensor is stopped.")
-            case .warmup, .questionMarks:
+            case .warmup, .temporarySensorIssue:
                 return LocalizedString("Sensor is warming up", comment: "The description of sensor algorithm state when sensor is warming up.")
             case .expired:
                 return LocalizedString("Sensor expired", comment: "The description of sensor algorithm state when sensor is expired.")
             case .sensorFailed:
                 return LocalizedString("Sensor failed", comment: "The description of sensor algorithm state when sensor failed.")
+            default:
+                return "Sensor state: \(String(describing: state))"
             }
         case .unknown(let rawValue):
             return String(format: LocalizedString("Sensor is in unknown state %1$d", comment: "The description of sensor algorithm state when raw value is unknown. (1: missing data details)"), rawValue)

--- a/G7SensorKit/AlgorithmState.swift
+++ b/G7SensorKit/AlgorithmState.swift
@@ -37,6 +37,7 @@ public enum AlgorithmState: RawRepresentable {
         case sensorFailedDueToRestart = 22
         case expired = 24
         case sensorFailed = 25
+        case sessionEnded = 26
     }
 
     case known(State)

--- a/G7SensorKit/AlgorithmState.swift
+++ b/G7SensorKit/AlgorithmState.swift
@@ -15,8 +15,26 @@ public enum AlgorithmState: RawRepresentable {
     public enum State: RawValue {
         case stopped = 1
         case warmup = 2
+        case excessNoise = 3
+        case firstOfTwoBGsNeeded = 4
+        case secondOfTwoBGsNeeded = 5
         case ok = 6
-        case questionMarks = 18
+        case needsCalibration = 7
+        case calibrationError1 = 8
+        case calibrationError2 = 9
+        case calibrationLinearityFitFailure = 10
+        case sensorFailedDuetoCountsAberration = 11
+        case sensorFailedDuetoResidualAberration = 12
+        case outOfCalibrationDueToOutlier = 13
+        case outlierCalibrationRequest = 14
+        case sessionExpired = 15
+        case sessionFailedDueToUnrecoverableError = 16
+        case sessionFailedDueToTransmitterError = 17
+        case temporarySensorIssue = 18
+        case sensorFailedDueToProgressiveSensorDecline = 19
+        case sensorFailedDueToHighCountsAberration = 20
+        case sensorFailedDueToLowCountsAberration = 21
+        case sensorFailedDueToRestart = 22
         case expired = 24
         case sensorFailed = 25
     }
@@ -48,7 +66,7 @@ public enum AlgorithmState: RawRepresentable {
         }
 
         switch state {
-        case .sensorFailed:
+        case .sensorFailed, .sensorFailedDuetoCountsAberration, .sensorFailedDuetoResidualAberration, .sessionFailedDueToTransmitterError, .sessionFailedDueToUnrecoverableError, .sensorFailedDueToProgressiveSensorDecline, .sensorFailedDueToHighCountsAberration, .sensorFailedDueToLowCountsAberration, .sensorFailedDueToRestart:
             return true
         default:
             return false
@@ -68,13 +86,13 @@ public enum AlgorithmState: RawRepresentable {
         }
     }
 
-    public var isInSensorError: Bool {
+    public var hasTemporaryError: Bool {
         guard case .known(let state) = self else {
             return false
         }
 
         switch state {
-        case .questionMarks:
+        case .temporarySensorIssue:
             return true
         default:
             return false
@@ -88,14 +106,10 @@ public enum AlgorithmState: RawRepresentable {
         }
 
         switch state {
-        case .stopped,
-             .warmup,
-             .questionMarks,
-             .expired,
-             .sensorFailed:
-            return false
         case .ok:
             return true
+        default:
+            return false
         }
     }
 }

--- a/G7SensorKit/G7CGMManager/G7BluetoothManager.swift
+++ b/G7SensorKit/G7CGMManager/G7BluetoothManager.swift
@@ -191,19 +191,20 @@ class G7BluetoothManager: NSObject {
         }
 
         if let peripheralID = activePeripheralIdentifier, let peripheral = centralManager.retrievePeripherals(withIdentifiers: [peripheralID]).first {
-            log.debug("Retrieved peripheral %{public}@", peripheral.identifier.uuidString)
+            log.default("Retrieved peripheral %{public}@", peripheral.identifier.uuidString)
             handleDiscoveredPeripheral(peripheral)
         } else {
             for peripheral in centralManager.retrieveConnectedPeripherals(withServices: [
                 SensorServiceUUID.advertisement.cbUUID,
                 SensorServiceUUID.cgmService.cbUUID
             ]) {
+                log.default("Found system-connected peripheral: %{public}@", peripheral.identifier.uuidString)
                 handleDiscoveredPeripheral(peripheral)
             }
         }
 
         if activePeripheral == nil {
-            log.debug("Scanning for peripherals")
+            log.default("Scanning for peripherals")
             centralManager.scanForPeripherals(withServices: [
                     SensorServiceUUID.advertisement.cbUUID
                 ],
@@ -257,7 +258,7 @@ class G7BluetoothManager: NSObject {
         if let delegate = delegate {
             switch delegate.bluetoothManager(self, shouldConnectPeripheral: peripheral) {
             case .makeActive:
-                log.debug("Making peripheral active: %{public}@", peripheral.identifier.uuidString)
+                log.default("Making peripheral active: %{public}@", peripheral.identifier.uuidString)
 
                 if let peripheralManager = activePeripheralManager {
                     peripheralManager.peripheral = peripheral
@@ -273,7 +274,7 @@ class G7BluetoothManager: NSObject {
                 self.centralManager.connect(peripheral)
 
             case .connect:
-                log.debug("Connecting to peripheral: %{public}@", peripheral.identifier.uuidString)
+                log.default("Connecting to peripheral: %{public}@", peripheral.identifier.uuidString)
                 self.centralManager.connect(peripheral)
                 let peripheralManager = G7PeripheralManager(
                     peripheral: peripheral,

--- a/G7SensorKit/G7CGMManager/G7CGMManager.swift
+++ b/G7SensorKit/G7CGMManager/G7CGMManager.swift
@@ -345,6 +345,7 @@ extension G7CGMManager: G7SensorDelegate {
             scanForNewSensor()
         }
 
+
         guard let activationDate = sensor.activationDate else {
             logDeviceCommunication("Unable to process sensor reading without activation date.", type: .error)
             return

--- a/G7SensorKit/G7CGMManager/G7CGMManager.swift
+++ b/G7SensorKit/G7CGMManager/G7CGMManager.swift
@@ -350,6 +350,7 @@ extension G7CGMManager: G7SensorDelegate {
             scanForNewSensor()
         }
 
+
         guard let activationDate = sensor.activationDate else {
             logDeviceCommunication("Unable to process sensor reading without activation date.", type: .error)
             return

--- a/G7SensorKit/G7CGMManager/G7CGMManager.swift
+++ b/G7SensorKit/G7CGMManager/G7CGMManager.swift
@@ -323,6 +323,11 @@ extension G7CGMManager: G7SensorDelegate {
         }
     }
 
+    public func sensor(_ sensor: G7Sensor, logComms comms: String) {
+        logDeviceCommunication("Sensor comms \(comms)", type: .receive)
+    }
+
+
     public func sensor(_ sensor: G7Sensor, didError error: Error) {
         logDeviceCommunication("Sensor error \(error)", type: .error)
     }
@@ -333,6 +338,11 @@ extension G7CGMManager: G7SensorDelegate {
             logDeviceCommunication("Sensor reading duplicate: \(message)", type: .error)
             updateDelegate(with: .noData)
             return
+        }
+
+        if message.algorithmState.sensorFailed {
+            logDeviceCommunication("Detected failed sensor... scanning for new sensor.", type: .receive)
+            scanForNewSensor()
         }
 
         guard let activationDate = sensor.activationDate else {

--- a/G7SensorKit/G7CGMManager/G7CGMManager.swift
+++ b/G7SensorKit/G7CGMManager/G7CGMManager.swift
@@ -345,6 +345,10 @@ extension G7CGMManager: G7SensorDelegate {
             scanForNewSensor()
         }
 
+        if message.algorithmState == .known(.sessionEnded) {
+            logDeviceCommunication("Detected session ended... scanning for new sensor.", type: .receive)
+            scanForNewSensor()
+        }
 
         guard let activationDate = sensor.activationDate else {
             logDeviceCommunication("Unable to process sensor reading without activation date.", type: .error)

--- a/G7SensorKit/G7CGMManager/G7Sensor.swift
+++ b/G7SensorKit/G7CGMManager/G7Sensor.swift
@@ -194,7 +194,10 @@ public final class G7Sensor: G7BluetoothManagerDelegate {
         if let sensorID = sensorID, sensorID == peripheralManager.peripheral.name {
 
             let suspectedEndOfSession: Bool
-            if pendingAuth && wasRemoteDisconnect {
+
+            if let activationDate = activationDate, Date() > activationDate.addingTimeInterval(G7Sensor.lifetime + G7Sensor.gracePeriod), pendingAuth, wasRemoteDisconnect
+            {
+                self.log.info("Sensor disconnected at %{public}@", activationDate.description)
                 suspectedEndOfSession = true // Normal disconnect without auth is likely that G7 app stopped this session
             } else {
                 suspectedEndOfSession = false
@@ -233,7 +236,7 @@ public final class G7Sensor: G7BluetoothManagerDelegate {
 
         guard response.count > 0 else { return }
 
-        log.debug("Received control response: %{public}@", response.hexadecimalString)
+        log.default("Received control response: %{public}@", response.hexadecimalString)
 
         switch G7Opcode(rawValue: response[0]) {
         case .glucoseTx?:

--- a/G7SensorKit/G7CGMManager/G7Sensor.swift
+++ b/G7SensorKit/G7CGMManager/G7Sensor.swift
@@ -197,9 +197,8 @@ public final class G7Sensor: G7BluetoothManagerDelegate {
 
             let suspectedEndOfSession: Bool
 
-            if let activationDate = activationDate, Date() > activationDate.addingTimeInterval(G7Sensor.lifetime + G7Sensor.gracePeriod), pendingAuth, wasRemoteDisconnect
-            {
-                self.log.info("Sensor disconnected at %{public}@", activationDate.description)
+            self.log.info("Sensor disconnected: wasRemoteDisconnect:%{public}@", String(describing: wasRemoteDisconnect))
+            if pendingAuth, wasRemoteDisconnect {
                 suspectedEndOfSession = true // Normal disconnect without auth is likely that G7 app stopped this session
             } else {
                 suspectedEndOfSession = false

--- a/G7SensorKit/G7CGMManager/G7Sensor.swift
+++ b/G7SensorKit/G7CGMManager/G7Sensor.swift
@@ -19,6 +19,8 @@ public protocol G7SensorDelegate: AnyObject {
 
     func sensor(_ sensor: G7Sensor, didError error: Error)
 
+    func sensor(_ sensor: G7Sensor, logComms comms: String)
+
     func sensor(_ sensor: G7Sensor, didRead glucose: G7GlucoseMessage)
 
     func sensor(_ sensor: G7Sensor, didReadBackfill backfill: [G7BackfillMessage])
@@ -255,7 +257,7 @@ public final class G7Sensor: G7BluetoothManagerDelegate {
                 }
             }
         default:
-            // We ignore all other known opcodes
+            self.delegate?.sensor(self, logComms: response.hexadecimalString)
             break
         }
     }

--- a/G7SensorKit/Messages/G7Opcode.swift
+++ b/G7SensorKit/Messages/G7Opcode.swift
@@ -10,6 +10,7 @@ import Foundation
 
 enum G7Opcode: UInt8 {
     case authChallengeRx = 0x05
+    case sessionStopTx = 0x28
     case glucoseTx = 0x4e
     case backfillFinished = 0x59
 }

--- a/G7SensorKitUI/G7CGMManager/G7CGMManager+UI.swift
+++ b/G7SensorKitUI/G7CGMManager/G7CGMManager+UI.swift
@@ -74,7 +74,7 @@ extension G7CGMManager: CGMManagerUI {
                 state: .warning)
         }
 
-        if let latestReading = latestReading, latestReading.algorithmState.isInSensorError {
+        if let latestReading = latestReading, latestReading.algorithmState.hasTemporaryError {
             return G7DeviceStatusHighlight(
                 localizedMessage: LocalizedString("Sensor\nIssue", comment: "G7 Status highlight text for sensor error"),
                 imageName: "exclamationmark.circle.fill",


### PR DESCRIPTION
Attempt at fixing https://github.com/LoopKit/Loop/issues/2286 (and maybe https://github.com/LoopKit/Loop/issues/2278).  

This change listens for `connectionEventDidOccur`, like #33, adds additional end of session detection based on algorithm state decodeing.