### PR TITLE
Fix calibration decoding, and lagged backfill processing

### DIFF
--- a/G7SensorKit/G7CGMManager/G7BackfillMessage.swift
+++ b/G7SensorKit/G7CGMManager/G7BackfillMessage.swift
@@ -32,17 +32,18 @@ public struct G7BackfillMessage: Equatable {
             return nil
         }
 
-        timestamp = data[0..<4].toInt()
+        
+        timestamp = data[0..<3].toInt()
 
         let glucoseBytes = data[4..<6].to(UInt16.self)
 
         if glucoseBytes != 0xffff {
             glucose = glucoseBytes & 0xfff
-            glucoseIsDisplayOnly = (glucoseBytes & 0xf000) > 0
         } else {
             glucose = nil
-            glucoseIsDisplayOnly = false
         }
+
+        glucoseIsDisplayOnly = data[7] & 0x10 != 0
 
         algorithmState = AlgorithmState(rawValue: data[6])
 

--- a/G7SensorKitTests/G7GlucoseMessageTests.swift
+++ b/G7SensorKitTests/G7GlucoseMessageTests.swift
@@ -131,6 +131,23 @@ final class G7GlucoseMessageTests: XCTestCase {
         let data = Data(hexadecimalString: "cf5802008f00060f10")!
         let message = G7BackfillMessage(data: data)!
         XCTAssertEqual(153807, message.timestamp)
+        XCTAssertEqual(143, message.glucose)
+        XCTAssertEqual(.known(.ok), message.algorithmState)
+        XCTAssertNil(message.condition)
+        XCTAssertEqual(false, message.glucoseIsDisplayOnly)
+        XCTAssertEqual(true, message.hasReliableGlucose)
+    }
+
+    func testBackfillTimestampWithHighByte() {
+        let data = Data(hexadecimalString: "f20e0d00ba00060ffb")!
+        let message = G7BackfillMessage(data: data)!
+        XCTAssertEqual(855794, message.timestamp)
+    }
+
+    func testBackfillCalibration() {
+        let data = Data(hexadecimalString: "f63d00008500061efe")!
+        let message = G7BackfillMessage(data: data)!
+        XCTAssertEqual(true, message.glucoseIsDisplayOnly)
     }
 
 }


### PR DESCRIPTION
Calibration flag was not being decoded correctly, and all readings were marked as non-calibration. This fixes that.

If iOS drops the backfillFinished message, the backfill buffer might contain old messages, and get flushed at a much later time improperly. If the flushing happens after a new sensor is paired, the timestamp interpretation can be very off (by applying the large backfill offsets to the new sensor start date) See https://github.com/LoopKit/Loop/issues/2291. This change flushes the backfill buffer on sensor disconnect, if there is anything in it.