### PR TITLE
Extend displaying remaining lifetime from 24 to 48 hrs

### DIFF
--- a/G7SensorKitUI/G7CGMManager/G7CGMManager+UI.swift
+++ b/G7SensorKitUI/G7CGMManager/G7CGMManager+UI.swift
@@ -102,13 +102,13 @@ extension G7CGMManager: CGMManagerUI {
     public var cgmLifecycleProgress: DeviceLifecycleProgress? {
         switch lifecycleState {
         case .ok:
-            // show remaining lifetime, if < 24 hours
+            // show remaining lifetime, if < 48 hours
             guard let expiration = sensorExpiresAt else {
                 return nil
             }
             let remaining = max(0, expiration.timeIntervalSinceNow)
 
-            if remaining < .hours(24) {
+            if remaining < .hours(48) {
                 return G7LifecycleProgress(percentComplete: 1-(remaining/lifetime), progressState: .warning)
             }
             return nil

--- a/G7SensorKitUI/G7CGMManager/G7CGMManager+UI.swift
+++ b/G7SensorKitUI/G7CGMManager/G7CGMManager+UI.swift
@@ -109,7 +109,8 @@ extension G7CGMManager: CGMManagerUI {
             let remaining = max(0, expiration.timeIntervalSinceNow)
 
             if remaining < .hours(48) {
-                return G7LifecycleProgress(percentComplete: 1-(remaining/lifetime), progressState: .warning)
+                let progressState: DeviceLifecycleProgressState = remaining < .hours(24) ? .warning : .normalCGM
+                return G7LifecycleProgress(percentComplete: 1-(remaining/lifetime), progressState: progressState)
             }
             return nil
         case .gracePeriod:


### PR DESCRIPTION
Allows for apps consuming G7SensorKit to display CGM lifecycle dependent UI when sensor has 48 hrs left before expiry and grace period as opposed to just 24 hrs. 

This was voiced during testing of https://github.com/nightscout/Trio/pull/1205 by testers on Trio.

Discussed this with @ps2 via DM and we agreed this was a sensible change, so users get ~2 days to be prepared for an upcoming sensor change. 